### PR TITLE
Remove depreciated parameter

### DIFF
--- a/ozdock.com/default.html
+++ b/ozdock.com/default.html
@@ -1,6 +1,6 @@
-﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-          "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-
+﻿<!--<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+          "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">-->
+<!DOCTYPE HTML>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <meta charset="utf-8" />
@@ -11,7 +11,7 @@
     <title>OzDock</title>
     <script src="//code.jquery.com/jquery-2.1.1.min.js"></script>
     <script src="scripts/jquery.nicescroll.min.js"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyADnNZGJgkzJlr6geXJ-ImljGkkKLT_0Z0&sensor=false&libraries=places"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyADnNZGJgkzJlr6geXJ-ImljGkkKLT_0Z0&libraries=places"></script>
     <script src="scripts/default.js"></script>
     <link href="default.css" rel="stylesheet" />
 </head>


### PR DESCRIPTION
Removed the depreciated sensor parameter for Google Maps API.
https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required